### PR TITLE
Herokuデプロイエラーの修正（本番環境でAWS S3を設定）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,6 @@
 
 /db/test.sqlite3
 
-/app/uploaders/
 /public/uploads/
 
 /.env

--- a/app/uploaders/card_image_uploader.rb
+++ b/app/uploaders/card_image_uploader.rb
@@ -1,0 +1,27 @@
+class CardImageUploader < CarrierWave::Uploader::Base
+  include CarrierWave::MiniMagick
+
+  if Rails.env.development? || Rails.env.test?
+    storage :file
+  else
+    storage :fog
+  end
+
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  def default_url
+    'card1.png'
+  end
+
+  def extension_allowlist
+    %w[jpg jpeg gif png]
+  end
+
+  def size_range
+    (0.megabytes)..(5.megabytes)
+  end
+
+  process resize_to_fill: [1700, 1100]
+end


### PR DESCRIPTION
・`NameError`の発生。
```
/app/app/models/card.rb:2:in `<class:Card>': uninitialized constant Card::CardImageUploader (NameError)
```

**対応**
・`.gitignore`から`/app/uploader/`を削除。
・`card_image_uploader.rb`をリポジトリに追加`push`。